### PR TITLE
Add mcpproxy-go to MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,7 @@ MCP工具聚合：
 14. [FastAPI-MCP](https://github.com/tadata-org/fastapi_mcp)
 15. [modelscope/mcp](https://modelscope.cn/mcp)
 16. [mcpm.sh](https://github.com/pathintegral-institute/mcpm.sh)
+17. [mcpproxy-go](https://github.com/smart-mcp-proxy/mcpproxy-go) - Open-source local MCP proxy. Routes multiple servers through single endpoint with BM25 tool filtering, quarantine security, and web UI.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adding mcpproxy-go - an open-source local MCP proxy with BM25 tool filtering, quarantine security, and web UI.

- Project: https://github.com/smart-mcp-proxy/mcpproxy-go