### PR TITLE
Add BGPT MCP to MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,7 @@ MCP工具聚合：
 14. [FastAPI-MCP](https://github.com/tadata-org/fastapi_mcp)
 15. [modelscope/mcp](https://modelscope.cn/mcp)
 16. [mcpm.sh](https://github.com/pathintegral-institute/mcpm.sh)
+17. [bgpt-mcp](https://github.com/connerlambden/bgpt-mcp) - 搜索科学论文，获取从全文研究中提取的结构化实验数据（方法、结果、样本量、质量评分）
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary

Adds **BGPT MCP** to the 模型上下文协议 MCP section.

BGPT MCP — 搜索科学论文，获取从全文研究中提取的结构化实验数据（方法、结果、样本量、质量评分）。

- **GitHub:** https://github.com/connerlambden/bgpt-mcp
- **Website:** https://bgpt.pro/mcp
- **Transport:** SSE (hosted cloud service)
- **Free tier:** 50 free searches