### PR TITLE
Add Agent Gateway to agent infrastructure tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 48. [MiroThinker](https://github.com/MiroMindAI/MiroThinker): an open-source search agent model, built for tool-augmented reasoning and real-world information seeking, aiming to match the deep research experience of OpenAI Deep Research and Gemini Deep Research.
 49. [Nexent](https://github.com/ModelEngine-Group/nexent): A zero-code platform for auto-generating agents — no orchestration, no complex drag-and-drop required, using pure language to develop any agent you want.
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
+51. [Agent Gateway](https://agent-gateway-kappa.vercel.app): Unified API giving LLM agents access to 37+ services (memory, wallets, scheduling, code execution, DeFi). Supports agent.json and llms.txt discovery.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary

- Adds **[Agent Gateway](https://agent-gateway-kappa.vercel.app)** to the 智能体 Agents section
- Agent Gateway is a unified API layer for LLM agents, providing 37+ services (memory, wallets, scheduling, code execution, DeFi)
- Supports `agent.json` and `llms.txt` discovery protocols for standardized tool integration

## Details

Agent Gateway gives LLM agents a single endpoint to access a wide range of infrastructure services, making it easy to build autonomous agent systems without integrating dozens of separate APIs.

Added as item #51 in the Agents section, following the existing numbered list format.