### PR TITLE
Add dna-claude-analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 48. [MiroThinker](https://github.com/MiroMindAI/MiroThinker): an open-source search agent model, built for tool-augmented reasoning and real-world information seeking, aiming to match the deep research experience of OpenAI Deep Research and Gemini Deep Research.
 49. [Nexent](https://github.com/ModelEngine-Group/nexent): A zero-code platform for auto-generating agents — no orchestration, no complex drag-and-drop required, using pure language to develop any agent you want.
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
+51. [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis): LLM-powered personal genome analysis toolkit that analyzes raw DNA data across 17 categories and generates visual reports.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Add [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the 智能体 Agents section.

An LLM-powered personal genome analysis toolkit that analyzes raw DNA data across 17 categories (ancestry, health risks, nutrition, pharmacogenomics, etc.) and generates visual reports in a terminal/hacker aesthetic.