### PR TITLE
Add Lumen: vision-first browser agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 48. [MiroThinker](https://github.com/MiroMindAI/MiroThinker): an open-source search agent model, built for tool-augmented reasoning and real-world information seeking, aiming to match the deep research experience of OpenAI Deep Research and Gemini Deep Research.
 49. [Nexent](https://github.com/ModelEngine-Group/nexent): A zero-code platform for auto-generating agents — no orchestration, no complex drag-and-drop required, using pure language to develop any agent you want.
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
+51. [Lumen](https://github.com/omxyz/lumen): A vision-first browser agent with self-healing deterministic replay over CDP. Screenshot → model → action loop with multi-provider support (Anthropic, Google).
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## What is Lumen?

[Lumen](https://github.com/omxyz/lumen) 是一个视觉优先的浏览器智能体，支持自修复确定性重放。

- **Screenshot → model → action loop** over Chrome DevTools Protocol
- **Self-healing action cache** for deterministic replay
- **Multi-provider support** (Anthropic, Google)
- Built-in stuck detection and completion verification
- TypeScript · MIT · [npm](https://www.npmjs.com/package/@omxyz/lumen) · [Docs](https://lumen.omlabs.xyz)

Added as #51 in the 智能体 Agents section.