### PR TITLE
新增 LLM Benchmark Costco 到评估章节

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 17. [YourBench](https://github.com/huggingface/yourbench): A Dynamic Benchmark Generation Framework.
 18. [MedEvalKit](https://github.com/alibaba-damo-academy/MedEvalKit): A Unified Medical Evaluation Framework.
 19. [OpenJudge](https://github.com/modelscope/OpenJudge): A Unified Framework for Holistic Evaluation and Quality Rewards.
+20. [LLM Benchmark Costco](https://github.com/joe1chief/llm-benchmark-costco): 一个可搜索的 LLM 评测基准数据库，收录 378+ 个跨 12 个能力维度的基准，支持内嵌 PDF 阅读、Mermaid 构建流程图、中英双语界面及 CI/CD 自动部署。[🌐 Live Demo](https://joe1chief.github.io/llm-benchmark-costco/)
 
 `LLM API 服务平台`：
 1. [Groq](https://groq.com/)


### PR DESCRIPTION
## 新增资源：LLM Benchmark Costco

[LLM Benchmark Costco](https://github.com/joe1chief/llm-benchmark-costco) 是一个可搜索的 LLM 评测基准数据库，收录 **378+ 个**跨 12 个能力维度的基准测试。

### 主要特性

- **378+ 基准** 覆盖 Agent 能力、通用语言、多模态、代码、科学推理、安全对齐、医疗健康等 12 个维度
- **内嵌 PDF 阅读** — 无需离开页面即可阅读完整论文
- **Mermaid 构建流程图** — 200+ 个基准包含数据集构建方式的可视化图表
- **多维度筛选** — 按类别、年份、难度、数据开放程度筛选
- **中英双语界面** — 完整的中英文界面和数据字段
- **CI/CD 自动部署** — GitHub Actions 在 benchmarks.json 变更时自动部署到 GitHub Pages
- **在线演示**: https://joe1chief.github.io/llm-benchmark-costco/

### 变更内容

在**评估 Evaluation**章节末尾新增一行：
```
20. [LLM Benchmark Costco](https://github.com/joe1chief/llm-benchmark-costco): 一个可搜索的 LLM 评测基准数据库，收录 378+ 个跨 12 个能力维度的基准，支持内嵌 PDF 阅读、Mermaid 构建流程图、中英双语界面及 CI/CD 自动部署。[🌐 Live Demo](https://joe1chief.github.io/llm-benchmark-costco/)
```
