### PR TITLE
Add Redigg to Research resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 - ArgusBot: https://github.com/waltstephen/ArgusBot
 - Station: https://github.com/dualverse-ai/station
 - Dr.Claw: https://github.com/OpenLAIR/dr-claw
+- Redigg: https://github.com/redigg/redigg
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary
Add Redigg (Autonomous Research Agent for Scientific Discovery) to the Research section.

## Project
- Repo: https://github.com/redigg/redigg

## Why
Redigg supports autonomous literature search, paper analysis, concept explanation, and report generation, which fits the research-agent/resource category.