### PR TITLE
Add Zoom In 电路简介（双语教程）

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 35. [cnblog: 第七子](https://www.cnblogs.com/theseventhson)
 36. [Implementation of all RAG techniques in a simpler way.](https://github.com/FareedKhan-dev/all-rag-techniques)
 37. [Theoretical Machine Learning: A Handbook for Everyone](https://www.tengjiaye.com/mlbook.html)
+38. [Zoom In 电路简介（双语教程）](https://github.com/Jonny-English/circuits-zoom-in)：中英双语 Jupyter Notebook 手动复现 Olah 等人 2020 年的经典论文「Zoom In: An Introduction to Circuits」，涵盖特征可视化与卷积神经网络中的机械可解释性。
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## 新增内容

在「教程 Tutorial」区新增一条双语教程资源：

**[Zoom In 电路简介（双语教程）](https://github.com/Jonny-English/circuits-zoom-in)**

> 中英双语 Jupyter Notebook 手动复现 Olah 等人 2020 年的经典论文「Zoom In: An Introduction to Circuits」，涵盖特征可视化与卷积神经网络中的机械可解释性。

## 为什么适合收录

- **双语内容**：中英文对照，直接服务中文学习者社区
- **动手实践**：可运行的 Jupyter Notebook，基于 PyTorch 实现
- **机械可解释性基础**：复现了 Distill 2020 的经典论文，该方向是当前理解 LLM 内部机制的核心方法论之一
- **教育价值高**：让中文读者能以母语学习 AI 可解释性领域的奠基性工作