### PR TITLE
Add Hindsight - AI agent memory by Vectorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 48. [MiroThinker](https://github.com/MiroMindAI/MiroThinker): an open-source search agent model, built for tool-augmented reasoning and real-world information seeking, aiming to match the deep research experience of OpenAI Deep Research and Gemini Deep Research.
 49. [Nexent](https://github.com/ModelEngine-Group/nexent): A zero-code platform for auto-generating agents — no orchestration, no complex drag-and-drop required, using pure language to develop any agent you want.
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
+51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 
 #### OpenClaw-Style
 


### PR DESCRIPTION
## Summary
- Adds [Hindsight](https://github.com/vectorize-io/hindsight) to the 智能体 Agents section
- Hindsight is a state-of-the-art, open-source long-term memory system for AI agents by Vectorize
- MIT-licensed, fully self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and many more frameworks

## Why it fits
Hindsight is a core building block for AI agents, providing persistent memory capabilities. It complements the agent frameworks already listed in this section.