### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,7 @@ MCP工具聚合：
 14. [LabClaw](https://github.com/wu-yc/LabClaw)
 15. [Modelscope Skills](https://modelscope.cn/skills)
 16. [Agent Skill](https://agentskill.sh/)
+17. [mmx-cli](https://github.com/MiniMax-AI/cli)
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` to the **技能 Skills** section so the mmx-cli skill is discoverable from this curated list
- Users can browse and install via the [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) SKILL.md directly
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**1 line changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- Browse the **技能 Skills** section — mmx-cli is now listed
- Click the link to verify it leads to the MiniMax-AI/cli repository