### PR TITLE
Add ClawBench to 评估 Evaluation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 17. [YourBench](https://github.com/huggingface/yourbench): A Dynamic Benchmark Generation Framework.
 18. [MedEvalKit](https://github.com/alibaba-damo-academy/MedEvalKit): A Unified Medical Evaluation Framework.
 19. [OpenJudge](https://github.com/modelscope/OpenJudge): A Unified Framework for Holistic Evaluation and Quality Rewards.
+20. [ClawBench](https://github.com/reacher-z/ClawBench): A browser-use agent benchmark with 153 tasks across 144 live websites in 15 categories, evaluating 7 frontier models on real-world web interaction (top 33.3% cutoff). 面向浏览器智能体的评测基准，覆盖 15 个类别共 144 个真实网站上的 153 个任务，对 7 个前沿模型进行真实网页交互评估。[[paper](https://arxiv.org/abs/2604.08523)]
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 17. [YourBench](https://github.com/huggingface/yourbench): A Dynamic Benchmark Generation Framework.
 18. [MedEvalKit](https://github.com/alibaba-damo-academy/MedEvalKit): A Unified Medical Evaluation Framework.
 19. [OpenJudge](https://github.com/modelscope/OpenJudge): A Unified Framework for Holistic Evaluation and Quality Rewards.
-20. [ClawBench](https://github.com/reacher-z/ClawBench): A browser-use agent benchmark with 153 tasks across 144 live websites in 15 categories, evaluating 7 frontier models on real-world web interaction (top 33.3% cutoff). 面向浏览器智能体的评测基准，覆盖 15 个类别共 144 个真实网站上的 153 个任务，对 7 个前沿模型进行真实网页交互评估。[[paper](https://arxiv.org/abs/2604.08523)]
+20. [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench): A browser-use benchmark with 283 tasks (V1 153 + V2 130) across 163 live websites and 15 life categories, using submission interception plus an LLM judge for outcome evaluation. 面向浏览器智能体的评测基准，覆盖15个类别、163个真实网站上的283个任务（V1 153 + V2 130），采用提交拦截与LLM评审进行结果评估。[[paper](https://arxiv.org/abs/2604.08523)] [[project](https://claw-bench.com/)]
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary

Adds [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) to the 评估 Evaluation section as item 20.

ClawBench is an open-source benchmark for browser-use agents, featuring:
- **283 tasks** (V1 153 + V2 130) across **163 live websites** in **15 life categories**
- Two-stage outcome evaluation: submission-request interception followed by an LLM judge
- Five synchronized evidence layers: session replay, screenshots, HTTP traffic, browser actions, and agent messages
- Paper: https://arxiv.org/abs/2604.08523
- Project: https://claw-bench.com/

## Why it fits

The Evaluation section already includes general-purpose toolkits (OpenCompass, lm-evaluation-harness, EvalScope) and specialized benchmarks (MedEvalKit, MathArena). ClawBench fills the gap for agent-on-the-live-web evaluation, complementing the agent frameworks listed in 智能体 Agents.

## Entry added

```
20. [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench): A browser-use benchmark with 283 tasks (V1 153 + V2 130) across 163 live websites and 15 life categories, using submission interception plus an LLM judge for outcome evaluation. 面向浏览器智能体的评测基准，覆盖15个类别、163个真实网站上的283个任务（V1 153 + V2 130），采用提交拦截与LLM评审进行结果评估。[[paper](https://arxiv.org/abs/2604.08523)] [[project](https://claw-bench.com/)]
```

The entry uses the canonical repository URL and current V1+V2 scope.