### PR TITLE
Add Not Human Search to Search section

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 3. [nanoPerplexityAI](https://github.com/Yusuke710/nanoPerplexityAI): The simplest open-source implementation of perplexity.ai.
 4. [curiosity](https://github.com/jank/curiosity): Try to build a Perplexity-like user experience.
 5. [MiniPerplx](https://github.com/zaidmukaddam/miniperplx): A minimalistic AI-powered search engine that helps you find information on the internet.
+6. [Not Human Search](https://nothumansearch.ai): Search engine for AI agents indexing 9,000+ AI tools and APIs by agentic readiness (llms.txt, OpenAPI, MCP, ai-plugin.json). REST API and MCP server for programmatic discovery.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Add [Not Human Search](https://nothumansearch.ai) to the 搜索 Search section.

Not Human Search is a search engine built for AI agents that indexes 9,000+ AI tools and APIs, scoring them by agentic readiness signals like llms.txt, OpenAPI specs, MCP servers, and ai-plugin.json manifests. It provides a REST API and MCP server for programmatic discovery.