### PR TITLE
Add AgentsMesh to 智能体 Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 49. [Nexent](https://github.com/ModelEngine-Group/nexent): A zero-code platform for auto-generating agents — no orchestration, no complex drag-and-drop required, using pure language to develop any agent you want.
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
+52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adding [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) to the **智能体 Agents** section (#52).

## Why
AgentsMesh 是自主托管的 AI Agent 工作力平台（The AI Agent Workforce Platform）— 远程 AI 工作站（AgentPods）+ 多 agent 协作 + Kanban + MCP server。

**Key features**:
- AgentPods — remote AI workstations with PTY sandbox + git worktree isolation
- Multi-agent collaboration via channels and pod bindings
- Built-in Kanban with ticket-pod binding and MR/PR integration
- Per-pod MCP server
- Self-hosted runners — code stays on your infrastructure
- Multi-Git (GitHub / GitLab / Gitee)
- Multi-tenant (Org > Team > User) + SSO/RBAC + air-gapped
- BYOK
- Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode

1.5k+ stars, v0.28.0 (2026-04-15), BSL-1.1 license (transitions to GPL-2.0-or-later on 2030-02-28).

Format follows existing entries (\`N. [Name](url): description\`).