### PR TITLE
Add grugbot420 to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 40. [coze-studio](https://github.com/coze-dev/coze-studio): An AI agent development platform with all-in-one visual tools, simplifying agent creation, debugging, and deployment like never before.
 41. [OxyGent](https://github.com/jd-opensource/OxyGent): An advanced Python framework that empowers developers to quickly build production-ready intelligent systems.
 42. [LazyCraft](https://github.com/LazyAGI/LazyCraft): LazyCraft 是一个基于 LazyLLM 构建的 AI Agent 应用开发与管理平台，旨在协助开发者以 低门槛、低成本 快速构建和发布大模型应用。
+43. [grugbot420](https://github.com/grug-group420/grugbot420): A neuromorphic cognitive engine in Julia for multi-model AI orchestration. Deploys domain-expert AI specimens through architectural configuration rather than traditional training.
 43. [OpenAgents](https://github.com/openagents-org/openagents): AI Agent Networks for Open Collaboration.
 44. [SandBox](https://github.com/agent-infra/sandbox): All-in-One Sandbox for AI Agents that combines Browser, Shell, File, MCP and VSCode Server in a single Docker container.
 45. [DeepAnalyze](https://github.com/ruc-datalab/DeepAnalyze): First agentic LLM for autonomous data science, supporting specific data tasks (data preparation, analysis, modeling, visualization, and insight) and data-oriented deep research (produce analyst-grade research reports).


### PR DESCRIPTION
## grugbot420

[grugbot420](https://github.com/grug-group420/grugbot420) is a neuromorphic cognitive engine written in Julia for multi-model AI orchestration. It deploys domain-expert AI specimens through architectural configuration rather than traditional training.

- License: MIT
- Language: Julia
- Source: https://github.com/grug-group420/grugbot420