### PR TITLE
Add TokenMix to 推理 Inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 51. [LlamaBarn](https://github.com/ggml-org/LlamaBarn): Run local LLMs on your Mac with a simple menu bar app.
 52. [Parallax](https://github.com/GradientHQ/parallax): a distributed model serving framework that lets you build your own AI cluster anywhere.
 53. [xLLM](https://github.com/jd-opensource/xllm): A high-performance inference engine for LLMs, optimized for diverse AI accelerators.
+54. [TokenMix](https://tokenmix.ai): One API key for GPT-5, Claude, Gemini, DeepSeek and 155+ LLMs through an OpenAI-compatible endpoint. Open-source SDKs in 10+ languages.
 
 
 <div align="right">


### PR DESCRIPTION
添加 [TokenMix](https://tokenmix.ai) 到 **推理 Inference** 章节末尾（item 54）。

TokenMix 是统一的 OpenAI 兼容 API，通过单一 key 访问 GPT-5、Claude、Gemini、DeepSeek 等 155+ LLMs。与列表中已有的 LiteLLM 项目定位相近。

开源 SDK 覆盖 10+ 语言（Python / Node.js / Rust / Go / Ruby / Java / .NET / PHP / Swift），全部链接在主页。