### PR TITLE
Add langgraph-crosschain to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
+53. [langgraph-crosschain](https://github.com/karthyick/langgraph-crosschain): LangGraph extension for cross-chain node communication, shared state, and message broadcasting between separate graphs. Enables `Chain1.NodeA → Chain2.NodeB` calls without merging into one monolithic graph.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adding [**langgraph-crosschain**](https://github.com/karthyick/langgraph-crosschain) to the **Agents (智能体)** section.

LangGraph extension specifically for **multi-agent and modular workflows**:
- Direct cross-chain node calls: `Chain1.NodeA → Chain2.NodeB`
- Shared state management across separate LangGraph instances
- Message broadcasting to multiple chains

Useful when agent specializations are split across separate LangGraph instances and need to coordinate without merging into one monolithic graph.

- `pip install langgraph-crosschain`
- MIT license

Thanks for maintaining this list!