### PR TITLE
feat: add KubeStellar Console kc-agent to AI Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
+53. [KubeStellar Console kc-agent](https://github.com/kubestellar/console): AI-powered multi-cluster Kubernetes MCP agent. Bridges AI assistants (Claude, Copilot, Cursor) to live Kubernetes clusters for natural language operations, real-time observability, and CNCF project integrations across edge and cloud.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adds **[KubeStellar Console kc-agent](https://github.com/kubestellar/console)** to the **智能体 Agents** section.

KubeStellar Console kc-agent is an AI-powered multi-cluster Kubernetes MCP agent:
- **MCP server** that bridges AI assistants (Claude, GitHub Copilot, Cursor) to live Kubernetes clusters
- Enables natural language operations: query health, manage workloads, execute tasks across clusters
- Real-time observability across edge and cloud clusters
- Integrates with CNCF Sandbox projects: Argo CD, Kyverno, Istio, OPA, Prometheus
- Open source, Apache 2.0 licensed

**Links:**
- GitHub: https://github.com/kubestellar/console
- Demo: https://console.kubestellar.io