### PR TITLE
技能 Skills: 增加 master-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1064,6 +1064,7 @@ MCP工具聚合：
 15. [Modelscope Skills](https://modelscope.cn/skills)
 16. [Agent Skill](https://agentskill.sh/)
 17. [mmx-cli](https://github.com/MiniMax-AI/cli)
+18. [master-skill](https://github.com/voidborne-d/master-skill): 输入行业自动蒸馏可装载的 Master OS skill, 兼容 Claude Code / OpenClaw / Codex
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
你好 WangRongsheng, 增加一个我维护的项目到 「技能 Skills」 列表.

**18. [master-skill](https://github.com/voidborne-d/master-skill)**: 输入行业自动蒸馏可装载的 Master OS skill, 兼容 Claude Code / OpenClaw / Codex.

**项目特点**:
- 输入一个行业 (e.g. 跨境电商 / 短视频投流 / 中国法), 自动跑 6 轨调研 (大佬 / 工具 / 工作流 / 正典 / 信源 / 术语)
- 蒸馏成可装载的 SKILL.md + meta.json + cli/ + sub-skills/, 兼容 Claude Code / OpenClaw / Codex
- 每个行业自动调用女娲思维框架蒸出 top 3 人物的 sub-skill
- 7 个示例行业全部通过 quality_check (12 项机械标准 + 多 figure 共识)

**作者**: voidborne-d (我自己), MIT 协议, 中文文档为主. 项目还很早期 (v1.0) 但端到端可跑通, 欢迎 issue / PR.

感谢维护这个 LLM 资源大全 🙏