### PR TITLE
Add PromptEden to Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 17. [YourBench](https://github.com/huggingface/yourbench): A Dynamic Benchmark Generation Framework.
 18. [MedEvalKit](https://github.com/alibaba-damo-academy/MedEvalKit): A Unified Medical Evaluation Framework.
 19. [OpenJudge](https://github.com/modelscope/OpenJudge): A Unified Framework for Holistic Evaluation and Quality Rewards.
+20. [PromptEden](https://www.prompteden.com): External LLM-output monitoring — tracks how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe brands and which competitors they recommend, refreshed daily across 9+ AI platforms.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adds [PromptEden](https://www.prompteden.com) to the **评估 Evaluation** section.

PromptEden monitors how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe a brand — and which competitors they recommend instead. Daily refresh across 9+ AI platforms; surfaces visibility scores, citation sources, and competitor mentions.

The other entries in this section evaluate LLMs against benchmarks/datasets. PromptEden is the external-facing complement: it evaluates how public LLMs answer real-world prompts about specific brands and topics. Different angle, same evaluation discipline.

Followed existing format (`N. [Name](url): Description.`).