### PR TITLE
Add ai-evaluation and traceAI to 评估 Evaluation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 17. [YourBench](https://github.com/huggingface/yourbench): A Dynamic Benchmark Generation Framework.
 18. [MedEvalKit](https://github.com/alibaba-damo-academy/MedEvalKit): A Unified Medical Evaluation Framework.
 19. [OpenJudge](https://github.com/modelscope/OpenJudge): A Unified Framework for Holistic Evaluation and Quality Rewards.
+20. [ai-evaluation](https://github.com/future-agi/ai-evaluation): Open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge, and guardrail scanners.
+21. [traceAI](https://github.com/future-agi/traceAI): OpenTelemetry-native tracing framework for LLM and AI agent applications.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary
- Adds [ai-evaluation](https://github.com/future-agi/ai-evaluation) — open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge, and guardrail scanners
- Adds [traceAI](https://github.com/future-agi/traceAI) — OpenTelemetry-native tracing framework for LLM and AI agent applications

Both entries added to the 评估 Evaluation section alongside lm-evaluation-harness, opencompass, DeepEval, etc.

## Test plan
- [x] Entries placed in Evaluation section
- [x] Formatting consistent with peers