### PR TITLE
Add APort to Agents resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
+53. [APort](https://github.com/aporthq/aport-integrations): Agent identity and policy enforcement integrations for AI agent tool calls and workflows.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary

Adds APort to the Agents section as a resource for agent identity and policy enforcement around AI agent tool calls and workflows.

## Why this fits

The Agents section already includes agent platforms and control-plane tooling. APort fits this area because its public integrations focus on securing and governing agent actions rather than being a general-purpose AI app.

## Validation

- Searched the README for an existing APort entry before adding this one.
- Ran `git diff --check`.