### PR TITLE
Add TeamOffsite to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
+53. [TeamOffsite](https://teamoffsite.ai): no-code orchestration platform for agent teams by [mercury.build](https://mercury.build). Build and manage teams, bring your own agents, and coordinate Cursor, Claude Code, Devin, and OpenClaw under one governance layer.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adds [TeamOffsite](https://teamoffsite.ai) to the **智能体 Agents** section (entry 53).

TeamOffsite is a no-code orchestration platform for agent teams by mercury.build — build and manage teams, bring your own agents, and coordinate Cursor, Claude Code, Devin, and OpenClaw under one governance layer. Fits alongside commercial agent platforms already listed (Coze, LinkAI, Baidu APPBuilder).

- Single entry appended to the numbered list, matching the `N. [Name](link): description` format

**Disclosure:** I am affiliated with TeamOffsite (mercury.build) — submitting our own product. Happy to adjust wording or placement.