### PR TITLE
Add awesome-agentic-ai-zh to 课程 Course — trilingual staged agentic-AI…

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,7 +898,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 55. [NanoChat](https://github.com/karpathy/nanochat): The best ChatGPT that $100 can buy.
 56. [斯坦福CS146S: The Modern Software Developer](https://themodernsoftware.dev/)
 57. [awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh): 三语(英 / 繁中 / 简中)Agentic AI 阶段式学习地图,8 个阶段从 LLM 基础到 multi-agent,配动手练习,精选 145+ 个相关项目。MIT。
-58. 
+
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>
 </div>

--- a/README.md
+++ b/README.md
@@ -897,7 +897,8 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 54. [Reinforcement Learning of Large Language Models](https://ernestryu.com/courses/RL-LLM.html)
 55. [NanoChat](https://github.com/karpathy/nanochat): The best ChatGPT that $100 can buy.
 56. [斯坦福CS146S: The Modern Software Developer](https://themodernsoftware.dev/)
-
+57. [awesome-agentic-ai-zh](https://github.com/WenyuChiou/awesome-agentic-ai-zh): 三语(英 / 繁中 / 简中)Agentic AI 阶段式学习地图,8 个阶段从 LLM 基础到 multi-agent,配动手练习,精选 145+ 个相关项目。MIT。
+58. 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>
 </div>


### PR DESCRIPTION
想把 awesome-agentic-ai-zh 加到 课程 Course 这一节。

这是我自己做、也一直在维护的一个 Agentic AI 学习地图,三语(英 / 繁中 / 简中),分 8 个阶段从 LLM 基础走到 multi-agent 系统,中间配动手练习,也精选了 145+ 个相关项目。

放 课程 Course 是因为它跟这节里的 llm-course、微软 generative-ai-for-beginners 是同一类:带学习顺序的成体系课程,不是单个框架或工具,所以没往 智能体 Agents 那节放。

仓库:https://github.com/WenyuChiou/awesome-agentic-ai-zh
在线站点:https://wenyuchiou.github.io/awesome-agentic-ai-zh/