### PR TITLE
Add AI Models Catalog — 4,587+ models across 95 providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 
 1. [LM Arena](https://lmarena.ai/zh)
 2. [Design Arena](https://www.designarena.ai/)
+3. [AI Models Catalog](https://github.com/i-need-token/ai-models): 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. Interactive catalog at [i-need-token.github.io/ai-models](https://i-need-token.github.io/ai-models/)
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Addition

**AI Models Catalog** — A structured catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. All data sourced from first-party APIs.

### Why this fits
- **Comprehensive** — 95 providers, 4,587+ models, 441 families
- **First-party data** — pricing, context windows, and capabilities verified against official provider APIs
- **Useful tools** — interactive catalog with search, filter, compare, export (CSV/JSON), price calculator, model picker
- **Open source** — MIT licensed, npm package, GitHub Action, YAML + JSON + CSV formats

### Links
- Repository: https://github.com/i-need-token/ai-models
- Interactive catalog: https://i-need-token.github.io/ai-models/

Added to the **推理 Inference** section alongside LLM Pricing.