### PR TITLE
Add langchain-langgraph-langsmith-tutorial to 教程 Tutorial section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 35. [Dolphin](https://github.com/bytedance/Dolphin): Document Image Parsing via Heterogeneous Anchor Prompting.
 36. [EasyDistill](https://github.com/modelscope/easydistill): Easy Knowledge Distillation for Large Language Models.
 37. [ContextGem](https://github.com/shcherbak-ai/contextgem): a free, open-source LLM framework that makes it radically easier to extract structured data and insights from documents.
+38. [langchain-langgraph-langsmith-tutorial](https://github.com/estelledc/langchain-langgraph-langsmith-tutorial) - 给编程零基础选手的 LangChain 1.3.x 中文教程，4 周 14 篇 learning-by-doing；含 AI 辅助学习元教程（7 条 prompt 心法 + 任务卡结构）+ 6 处 1.3.x 破坏性变更修法实测。
 38. [OCRFlux](https://github.com/chatdoc-com/OCRFlux): a lightweight yet powerful multimodal toolkit that significantly advances PDF-to-Markdown conversion, excelling in complex layout handling, complicated table parsing and cross-page content merging.
 39. [DataFlow](https://github.com/OpenDCAI/DataFlow): Easy Data Preparation with latest LLMs-based Operators and Pipelines.
 40. [DatasetLoom (`multimodal`)](https://github.com/599yongyang/DatasetLoom): 一个面向多模态大模型训练的智能数据集构建与评估平台.


### PR DESCRIPTION
## 新增条目

- 项目：[langchain-langgraph-langsmith-tutorial](https://github.com/estelledc/langchain-langgraph-langsmith-tutorial)
- 章节：教程 Tutorial

## 简介

面向编程零基础学习者的 LangChain 1.3.x 中文教程，4 周共 14 篇 learning-by-doing 实战章节，覆盖 LangChain / LangGraph / LangSmith 全链路。每篇采用「日常类比 → 概念 → 代码 → 踩坑」四段任务卡结构。

## 与已收录条目的差异化

本节多数为 B 站 / YTB / Blog 频道入口或英文 Tutorial。本仓库定位：

1. **零基础定位 + GitHub 教程仓库**：14 个独立可执行 final/.py 全部经实测，附完整 setup / debug-recipes
2. **LangChain 1.3.x 实测**：6 处破坏性变更修法（pydantic_v1 / langchain_classic / LangChainStringEvaluator 等）
3. **AI 辅助学习元教程**：7 条 prompt 心法 + 任务卡结构，对 AI 时代的自学者有迁移价值

## 仓库现状

- Stars: 14（小而新，但定位差异化清晰）
- pre-commit hook 强制校验链接、来源字段
- 维护承诺：跟进 LangChain 2.x 升级
