### PR TITLE
Add EmbedGuard to RAG (知识库) section

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 33. [XRAG](https://github.com/DocAILab/XRAG): a benchmarking framework designed to evaluate the foundational components of advanced Retrieval-Augmented Generation (RAG) systems.
 34. [Rankify](https://github.com/DataScienceUIBK/rankify): A Comprehensive Python Toolkit for Retrieval, Re-Ranking, and Retrieval-Augmented Generation.
 35. [RAG-Anything](https://github.com/HKUDS/RAG-Anything): All-in-One RAG System.
+36. [EmbedGuard](https://github.com/neerazz/embedguard): A lightweight guardrail layer for RAG pipelines that screens embedding-stage inputs to detect prompt-injection and adversarial retrieval content before it reaches the generator.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adds **EmbedGuard** to the RAG (知识库) list.

[EmbedGuard](https://github.com/neerazz/embedguard) is a lightweight, open-source (MIT) guardrail layer for RAG pipelines that screens embedding-stage inputs to detect prompt-injection and adversarial retrieval content before it reaches the generator. It complements existing RAG frameworks in the list by adding an input-security layer.

- Single entry appended in the existing numbered format (item 36)
- No reordering or other changes

Thanks for maintaining this resource!