### PR TITLE
Add Promptra to Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 
 1. [LM Arena](https://lmarena.ai/zh)
 2. [Design Arena](https://www.designarena.ai/)
+3. [Promptra](https://promptra.ru/): OpenAI-compatible gateway for Claude, GPT, Gemini, DeepSeek, Qwen and other LLMs. Russian-market focused.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## What this adds

Adds **Promptra** to the *体验 Usage* section as a single line entry, following the existing format used for LM Arena and Design Arena.

Promptra is an OpenAI-compatible API gateway that aggregates Claude, GPT, Gemini, DeepSeek, Qwen and other LLMs behind a single endpoint.

## Why it fits this list

The Usage section currently lists ways to access and try multiple LLM models (LM Arena, Design Arena). Promptra fits the same role — it lets developers and teams query multiple frontier and open-source LLMs through one OpenAI-compatible API, which complements the chat/comparison tools already listed.

I noted the Russian-market focus explicitly in the description to be honest about scope; the API and OpenAI compatibility itself are language-neutral and useful to anyone working with multi-provider LLM access.

## Links

- Site: https://promptra.ru/
- Open source: https://github.com/solsemssa-alt/promptra-web