### PR TITLE
feat: add TWZRD Agent Intel to MCP aggregation list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,7 @@ MCP工具聚合：
 14. [FastAPI-MCP](https://github.com/tadata-org/fastapi_mcp)
 15. [modelscope/mcp](https://modelscope.cn/mcp)
 16. [mcpm.sh](https://github.com/pathintegral-institute/mcpm.sh)
+17. [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server for AI agent trust scoring on Solana. On-chain reputation scoring, pre-dispatch trust gating, signed receipts. Zero-install Streamable HTTP endpoint.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>

--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,7 @@ MCP工具聚合：
 14. [FastAPI-MCP](https://github.com/tadata-org/fastapi_mcp)
 15. [modelscope/mcp](https://modelscope.cn/mcp)
 16. [mcpm.sh](https://github.com/pathintegral-institute/mcpm.sh)
+17. [TWZRD Agent Intel](https://intel.twzrd.xyz): On-chain trust scoring and identity verification MCP server for AI agents on Solana. Free tools: `score_agent` (reputation score), `preflight_check` (trust gate); paid: `get_trust_receipt` (signed on-chain proof via HTTP 402).
 17. [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server for AI agent trust scoring on Solana. On-chain reputation scoring, pre-dispatch trust gating, signed receipts. Zero-install Streamable HTTP endpoint.
 
 <div align="right">


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **MCP工具聚合** (MCP tools aggregation) section as item #17.

TWZRD Agent Intel is a Streamable HTTP MCP server for **on-chain trust scoring and identity verification of AI agents on Solana**:

| Tool | Type | Description |
|------|------|-------------|
| `score_agent(wallet)` | Free | Returns 0-100 on-chain trust score + risk flags |
| `preflight_check(wallet)` | Free | Returns PASS/FAIL gate for agent authorization |
| `get_trust_receipt(wallet)` | Paid (HTTP 402 / x402) | Signed on-chain proof of agent identity and behavior |

### MCP server details

```json
{
  "mcpServers": {
    "twzrd-agent-intel": {
      "url": "https://intel.twzrd.xyz/mcp"
    }
  }
}
```

- **Transport**: Streamable HTTP (no local setup, no API key required)
- **Chain**: Solana mainnet
- **Use case**: Multi-agent systems that need to verify peer-agent trustworthiness before delegating tasks or funds