### PR TITLE
Add AugmentClaude to 技能 Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,7 @@ MCP工具聚合：
 15. [Modelscope Skills](https://modelscope.cn/skills)
 16. [Agent Skill](https://agentskill.sh/)
 17. [mmx-cli](https://github.com/MiniMax-AI/cli)
+18. [AugmentClaude](https://augmentclaude.com/)
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
在技能聚合列表末尾追加一行（仅名称 + 链接，与现有条目格式一致）。

AugmentClaude（https://augmentclaude.com）是一个免费、人工精选的 Claude Code 技能市场，包含技能、bundles、MCP servers 和 agents，每个条目均注明原作者并附 GitHub 源链接。

One-line addition to the skills aggregator list (name + link only, matching existing entries). AugmentClaude is a free, hand-picked marketplace of Claude Code skills, bundles, MCP servers, and agents — every entry credited to its original author.

Disclosure: 我是该站点的创建者 / I'm the founder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)