### PR TITLE
添加 GCF Proxy 到 MCP 工具列表

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,6 +1065,7 @@ MCP工具聚合：
 14. [FastAPI-MCP](https://github.com/tadata-org/fastapi_mcp)
 15. [modelscope/mcp](https://modelscope.cn/mcp)
 16. [mcpm.sh](https://github.com/pathintegral-institute/mcpm.sh)
+17. [GCF Proxy](https://github.com/blackwell-systems/gcf-proxy): MCP 工具响应 token 压缩代理，零代码接入，节省 71% token。支持 JSON、YAML、TOML、CSV、MessagePack 五种格式，330 亿+ 无损往返验证。[格式规范](https://gcformat.com) | [基准测试](https://gcformat.com/guide/benchmarks.html)
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## 摘要

在 MCP 工具聚合列表中添加 GCF Proxy。

GCF Proxy 是 MCP 工具响应的零代码 token 压缩代理：

- 节省 71% token（比 JSON 少 71%）
- 支持 JSON、YAML、TOML、CSV、MessagePack 五种格式
- 所有前沿模型 100% 理解准确率（1700+ 次评估）
- 330 亿+ 无损往返验证
- 支持 pip、npm、go install 安装
- MIT 许可

网站：https://gcformat.com
基准测试：https://gcformat.com/guide/benchmarks.html
GitHub：https://github.com/blackwell-systems/gcf-proxy