### PR TITLE
Add NarraNexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
+53. [NarraNexus](https://github.com/NetMindAI-Open/NarraNexus): Ready-to-run AI agent team workspace by NetMind.AI with persistent memory, multi-agent collaboration (PM/dev/deployment/research), MCP-style tool integrations, and composable modules (Memory, Awareness, Chat, RAG, Jobs, Skills).
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
NarraNexus is a ready-to-run AI agent team workspace by NetMind.AI. Unlike typical agent frameworks, it ships a complete team of agents that already remember, collaborate, and use tools from day one — with persistent memory, multi-agent collaboration (PM/dev/deployment/research agents), and MCP-style tool integrations.

GitHub: https://github.com/NetMindAI-Open/NarraNexus
Portal: https://www.narra.nexus/