### PR TITLE
Add NotFair to Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,6 +1094,7 @@ MCP工具聚合：
 15. [Modelscope Skills](https://modelscope.cn/skills)
 16. [Agent Skill](https://agentskill.sh/)
 17. [mmx-cli](https://github.com/MiniMax-AI/cli)
+18. [NotFair](https://github.com/nowork-studio/NotFair): Open-source Claude Code skills for SEO, GEO, Google Ads ([google-ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads)) and Meta Ads ([meta-ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads)), connecting to live data via the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Hi, and thanks for maintaining this list — the Skills section is a really useful roundup.

I'd like to suggest adding NotFair (https://github.com/nowork-studio/NotFair), an open-source (MIT, ~2.9k stars) set of Claude Code skills for marketing work: SEO and GEO (site analysis, keyword research, meta tags, schema markup, content writing), Google Ads, and Meta Ads. It fits alongside the other Claude Code skill collections already listed here.

The skills connect to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

I added it as a single entry at the end of the Skills section to match the surrounding style. Happy to reword, move, or trim it however you prefer.