### PR TITLE
docs: add 《AI 编程的第一性原理》 to Book section

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,8 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 21. [《The Smol Training Playbook: The Secrets to Building World-Class LLMs》](https://github.com/WangRongsheng/awesome-LLM-resources/blob/main/books/the-smol-training-playbook-the-secrets-to-building-world-class-llms.pdf)
 22. [《从零开始构建智能体》——从零开始的智能体原理与实践教程](https://github.com/datawhalechina/hello-agents)
 23. [《Hands-On Modern RL》](https://github.com/walkinglabs/hands-on-modern-rl)
+24. [《AI 编程的第一性原理 / First Principles of AI Coding》](https://github.com/caozhiyi/ai-programming-book) —— 从模型行为、Agent 执行、记忆与上下文，到可验证的工程闭环，系统推导 AI 编程从生成走向交付。
+
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
### Description / 变更描述

在 `书籍 Book` 分组末尾添加了开源书籍《AI 编程的第一性原理》。

* **书籍名称 / Title:** 《AI 编程的第一性原理 / First Principles of AI Coding》
* **链接 / Link:** https://github.com/caozhiyi/ai-programming-book
* **介绍 / Introduction:** 从模型行为、Agent 执行、记忆与上下文，到可验证的工程闭环，系统推导 AI 编程从生成走向交付。

这本书从 LLM 的基本物理约束出发，系统推导了 Agentic 架构、上下文管理以及可验证的闭环等工程设计。希望它能为社区在 AI 辅助开发/编程方向上提供有价值的参考，感谢维护这么棒的资源列表！