### PR TITLE
Add llm-speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 17. [YourBench](https://github.com/huggingface/yourbench): A Dynamic Benchmark Generation Framework.
 18. [MedEvalKit](https://github.com/alibaba-damo-academy/MedEvalKit): A Unified Medical Evaluation Framework.
 19. [OpenJudge](https://github.com/modelscope/OpenJudge): A Unified Framework for Holistic Evaluation and Quality Rewards.
+20. [llm-speed](https://llm-speed.com): Crowdsourced, cryptographically signed benchmarks of LLM inference speed (decode tok/s, TTFT) across consumer GPUs, Apple Silicon, and hosted APIs.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Hi! Adding [llm-speed](https://llm-speed.com), a crowdsourced benchmark
of how fast LLMs actually run (decode tok/s, TTFT, latency percentiles)
across hosted APIs, consumer GPUs, and Apple Silicon under one
reproducible workload suite (`suite-v1`).

Why it fits this list:
- **Reproducible**: open-source CLI (`pipx install llm-speed`) runs the
  same workload pack on any machine; every published number links
  back to the run record that produced it.
- **Trust chain**: dual-domain SHA-256 sidecar (CDN + GitHub Releases),
  Apache-2.0, public source at github.com/meadow-kun/llm-speed.
- **Open data**: every submission is JWS-signed and queryable via
  `https://api.llm-speed.com/v1/results`.

Following existing format / position. Happy to adjust the blurb or
section if you'd prefer a different fit.
