### PR TITLE
Add Darkmoon

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 49. [Nexent](https://github.com/ModelEngine-Group/nexent): A zero-code platform for auto-generating agents — no orchestration, no complex drag-and-drop required, using pure language to develop any agent you want.
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
+52. [Darkmoon](https://github.com/ASCIT31/Dark-Moon): 开源自主式 AI 渗透测试平台，通过 Markdown 剧本与智能体推理编排 80 多种攻击工具，基于 MCP 控制执行，覆盖 Web、云、Active Directory、Kubernetes、API 与内网渗透，并为每个发现提供证据链，模型无关且针对 Claude Opus 优化。
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
 
 <div align="right">


### PR DESCRIPTION
在「智能体 Agents」列表中新增 Darkmoon，一款 GPL-3.0 开源的自主式 AI 智能体，专注于自动化渗透测试。它通过 Markdown 剧本与智能体推理编排 80 多种攻击工具，基于 MCP 控制执行。