### PR TITLE
Add PieKBS to 知识库 RAG section

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 33. [XRAG](https://github.com/DocAILab/XRAG): a benchmarking framework designed to evaluate the foundational components of advanced Retrieval-Augmented Generation (RAG) systems.
 34. [Rankify](https://github.com/DataScienceUIBK/rankify): A Comprehensive Python Toolkit for Retrieval, Re-Ranking, and Retrieval-Augmented Generation.
 35. [RAG-Anything](https://github.com/HKUDS/RAG-Anything): All-in-One RAG System.
+36. [PieKBS](https://github.com/pieteams/piekbs): A local-first knowledge search engine for agents with FTS5 full-text search and graph-based document expansion via citation/support/wiki links.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Hi, thanks for maintaining this list - it's a great resource.

I'd like to add **PieKBS** to the 知识库 RAG section.

- Repo: https://github.com/pieteams/piekbs
- License: MIT
- Docs: https://pieteams.github.io/piekbs/

PieKBS is a local-first knowledge search engine for agents. It distills raw documents into a structured Markdown wiki and exposes MCP tools for search and deep-reading. Key features:

- **FTS5 full-text search** with BM25 scoring (no embedding required)
- **Graph-based document expansion** via citation/support/wiki/related_to links
- **Multi-hop tag expansion** for discovering related documents through shared keywords
- **MCP protocol support** for seamless integration with AI agents
- **Pure Go binary** with no external dependencies

Happy to adjust the wording or placement if needed.