### PR TITLE
Add Tree Ring Memory to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
+53. [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory): Framework-agnostic, local-first memory lifecycle for AI agents with a Rust CLI, SQLite/FTS recall, forgetting, audit, consolidation, DOX/Revolve adapters, and TUI.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary\n\nAdd Tree Ring Memory to the Agents section. It is a framework-agnostic, local-first memory lifecycle layer for AI agents with a Rust CLI, SQLite/FTS recall, forgetting, audit, consolidation, DOX/Revolve adapters, and TUI.\n\n## Why it fits\n\nThe Agents section already includes agent memory and MCP-adjacent infrastructure such as Hindsight and AgentsMesh, so Tree Ring Memory belongs with related agent memory lifecycle tooling.