### PR TITLE
Add LLMGraph to 智能体 Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
+53. [LLMGraph](https://llmgraph.ai): No-code visual builder for LLM workflows and AI agents; one-click deploy to REST API + embeddable chat widget.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adds [LLMGraph](https://llmgraph.ai) to the 智能体 Agents section — a no-code visual builder for LLM workflows and AI agents with one-click deploy to a REST API and an embeddable chat widget. Entry format matches the existing numbered list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)