### PR TITLE
Add usage to 代码 Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 23. [Kimi-CLI](https://github.com/MoonshotAI/kimi-cli)
 24. [opencode](https://github.com/anomalyco/opencode)
 25. [Multica](https://github.com/multica-ai/multica)
+26. [usage](https://github.com/aqua5230/usage): 把 Claude Code / Codex 额度钉在 macOS 菜单栏，零 Token 消耗的用量监控。
 
 
 <div align="right">


### PR DESCRIPTION
Adds [usage](https://github.com/aqua5230/usage) — an open-source (AGPL-3.0) macOS menu bar app that pins Claude Code and Codex quota (5-hour / weekly) to the screen, with burn-rate predictions and offline HTML usage reports. It never calls the Anthropic/OpenAI API; all numbers come from local files, so monitoring adds zero token overhead. Installable via `brew install --cask aqua5230/usage/usage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)