### PR TITLE
Add Hivekeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
+53. [Hivekeep](https://github.com/MarlBurroW/hivekeep): Self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI. Agents collaborate and build their own tools, mini-apps and plugins; reachable over Telegram, Slack, Discord and Matrix. Single container (Bun + SQLite).
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adds Hivekeep to the 智能体 Agents section (appended as entry 53, next to Hindsight and AgentsMesh).

Hivekeep is a self-hosted, MIT-licensed platform to run a team of specialized AI agents with persistent memory and a web UI; agents collaborate and build their own tools, mini-apps and plugins; reachable over Telegram, Slack, Discord and Matrix; single container (Bun + SQLite).

Open source: https://github.com/MarlBurroW/hivekeep (MIT). Actively maintained.

Disclosure: I am the author of the project.