### PR TITLE
Add Tura local open-source coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 23. [Kimi-CLI](https://github.com/MoonshotAI/kimi-cli)
 24. [opencode](https://github.com/anomalyco/opencode)
 25. [Multica](https://github.com/multica-ai/multica)
+26. [Tura](https://github.com/Tura-AI/tura): A local-first open-source coding agent written in Rust, with CLI, TUI, desktop, and web interfaces plus OpenAI-compatible and local model support.
 
 
 <div align="right">

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 23. [Kimi-CLI](https://github.com/MoonshotAI/kimi-cli)
 24. [opencode](https://github.com/anomalyco/opencode)
 25. [Multica](https://github.com/multica-ai/multica)
-26. [Tura](https://github.com/Tura-AI/tura): A local-first open-source coding agent written in Rust, with CLI, TUI, desktop, and web interfaces plus OpenAI-compatible and local model support.
+26. [Tura](https://github.com/Tura-AI/tura): Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.
 
 
 <div align="right">


### PR DESCRIPTION
## Tura: 16.7% better performance, 77.5% fewer rounds.

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.

This PR adds [Tura](https://github.com/Tura-AI/tura) to the **代码 Coding** section alongside other terminal coding agents. The Listing uses the root README's exact standard description.

- Website: https://turaai.net/
- Public benchmark: https://turaai.net/benchmark
- Validation: `git diff --check` passes.

Disclosure: I am affiliated with the Tura project.

AI-assistance disclosure: AI assistance was used to prepare and verify this submission; I reviewed the repository scope, duplicate state, diff, and final wording.