### PR TITLE
Add fractal to 智能体 Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
+53. [fractal](https://github.com/plasma-ai/fractal): Hierarchical coding-agent orchestrator with recursive delegation, per-node Git worktrees, configurable limits, persistent SQLite state, and live terminal monitoring and steering.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Adds [fractal](https://github.com/plasma-ai/fractal) to the **智能体 Agents** section as item 53.

fractal is an Apache-2.0 runtime for hierarchical coding-agent loops. It supports recursive delegation, per-node Git worktrees, configurable limits, persistent SQLite state, and live terminal monitoring and steering.

## Why

- Adds a recursive hierarchy model to the section's multi-agent frameworks and platforms
- Keeps delegated changes in separate Git worktrees
- Makes long-running workflows inspectable through persistent state and live controls

## Validation

- `git diff --check`
- Confirmed the new entry follows item 52 as item 53
- Confirmed the repository URL returns HTTP 200
- Duplicate README, history, issue, and pull-request searches found no existing fractal submission

Disclosure: I am affiliated with Plasma AI, which maintains fractal.
