### PR TITLE
Add StructEval to LLM evaluation resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 17. [YourBench](https://github.com/huggingface/yourbench): A Dynamic Benchmark Generation Framework.
 18. [MedEvalKit](https://github.com/alibaba-damo-academy/MedEvalKit): A Unified Medical Evaluation Framework.
 19. [OpenJudge](https://github.com/modelscope/OpenJudge): A Unified Framework for Holistic Evaluation and Quality Rewards.
+20. [StructEval](https://github.com/TIGER-AI-Lab/StructEval): A TMLR 2025 benchmark evaluating LLM structured-output generation and format conversion across 18 formats and 44 task types, including rendered HTML and SVG outputs. [[paper](https://arxiv.org/abs/2505.20139)] [[project](https://structeval.github.io/)] [[dataset](https://huggingface.co/datasets/TIGER-Lab/StructEval)]
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary

Adds StructEval to the existing 评估 Evaluation section using the repository’s numbered resource format.

StructEval is a TMLR 2025 benchmark evaluating LLM structured-output generation and format conversion across 18 formats and 44 task types, including rendered HTML and SVG outputs. The entry links to the canonical code, paper, project page, and dataset.

## Sources

- Code: https://github.com/TIGER-AI-Lab/StructEval
- Paper: https://arxiv.org/abs/2505.20139
- Project: https://structeval.github.io/
- Dataset: https://huggingface.co/datasets/TIGER-Lab/StructEval

The repository is actively maintained and has recent accepted/open resource PRs. This submission is made by the StructEval/ClawBench maintainer account (reacher-z) for factual discoverability; please review independently.