### PR TITLE
Add Soup to 微调 Fine-Tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
 50. [Twinkle](https://github.com/modelscope/twinkle): a lightweight, client-server training framework engineered with modular, high-cohesion interfaces.
 51. [NeMo AutoModel](https://github.com/NVIDIA-NeMo/Automodel): Pytorch Distributed native training library for LLMs/VLMs with OOTB Hugging Face support.
 52. [VeOmni](https://github.com/ByteDance-Seed/VeOmni): Scaling Any Modality Model Training with Model-Centric Distributed Recipe Zoo.
+53. [Soup](https://github.com/MakazhanAlpamys/Soup): One-config CLI for LLM post-training (SFT/DPO/GRPO/KTO/ORPO). Layer streaming trains an 8B model on a 4 GB laptop GPU by streaming the frozen base from host RAM one decoder layer at a time.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Soup is a CLI for LLM post-training that takes a single YAML config and runs SFT, DPO, GRPO, KTO, ORPO, plus evaluation gating and GGUF export.

Compared to the other entries in this section, its distinguishing feature is layer streaming: the frozen base model stays in host RAM and is streamed into two pre-allocated VRAM buffers one decoder layer at a time, so peak VRAM is bounded by a single layer rather than the whole model. This puts Llama-3.1-8B at 119.6 tok/s in 3.32 GB peak on an RTX 3050 4 GB laptop GPU.

Measurement method and raw numbers, including the bit-exactness gates against a resident run, are in https://github.com/MakazhanAlpamys/Soup/tree/main/benchmarks. Apache-2.0.