### PR TITLE
Evaluation: add verbatim-citation-gate (deterministic citation check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 17. [YourBench](https://github.com/huggingface/yourbench): A Dynamic Benchmark Generation Framework.
 18. [MedEvalKit](https://github.com/alibaba-damo-academy/MedEvalKit): A Unified Medical Evaluation Framework.
 19. [OpenJudge](https://github.com/modelscope/OpenJudge): A Unified Framework for Holistic Evaluation and Quality Rewards.
+20. [verbatim-citation-gate](https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate): Deterministic check of whether a quoted span literally appears in the source it was attributed to, returning found/misattributed/not_found with no model calls.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
Self-submission: verbatim-citation-gate is maintained by the submitting author.

Adds one entry to **评估 Evaluation**.

**What it does.** Given a quoted span and the document it was attributed to, it checks whether that span literally appears there. Returns `found` / `misattributed` / `not_found`, and fails closed on malformed input rather than raising. Zero model calls, no API keys, no framework dependency.

**Why this section.** The tools listed here evaluate model output, and most of them need a model or a hosted platform to do it. This one is the cheap deterministic layer underneath: a fabricated quote is caught by string comparison at zero cost, so the expensive evaluator only ever sees what survived. It is a complement to the harnesses already on the list, not a replacement for one.

**The boundary, stated plainly.** It verifies verbatim overlap only. It does **not** judge whether the cited passage supports the claim, and it does not detect paraphrased fabrication. Anything beyond literal overlap is out of scope by design.

**Verification as of 2026-08-06:**
- License: MIT
- Latest commit: 2026-08-05
- Tests: 17 passing on Python 3.9/3.11/3.13 across Linux, macOS and Windows (CI on every push, plus weekly)
- Duplicate check: README contains no prior `verbatim-citation-gate` name or URL
- Non-Latin coverage: normalization is Unicode-aware, with regression tests in Cyrillic, CJK and accented Latin. This came from an outside contributor who caught that an ASCII-only filter was silently passing fabricated non-English quotes.

Happy to move it to a different section or shorten the description if you prefer.