### PR TITLE
Add AMD Strix Halo local LLM setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,6 +1031,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 35. [cnblog: 第七子](https://www.cnblogs.com/theseventhson)
 36. [Implementation of all RAG techniques in a simpler way.](https://github.com/FareedKhan-dev/all-rag-techniques)
 37. [Theoretical Machine Learning: A Handbook for Everyone](https://www.tengjiaye.com/mlbook.html)
+38. [AMD Strix Halo Local LLM Guide](https://github.com/hogeheer499-commits/strix-halo-guide): Reproducible Ubuntu, Ollama, llama.cpp, Vulkan/RADV, and ROCm setup with public benchmark evidence for Ryzen AI MAX+ 395 systems.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary

Adds a focused AMD Strix Halo local-LLM setup and benchmark guide to the Tutorial section.

The guide covers a reproducible Ubuntu path for Ryzen AI MAX+ 395 systems across Ollama, llama.cpp, Vulkan/RADV, and ROCm, with public benchmark evidence and documented failed routes.

## Scope

- one README entry
- no existing recommendations changed
- direct link to the maintained public guide