### PR TITLE
Add Open Multi-Agent to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 50. [Yunjue-Agent](https://github.com/YunjueTech/Yunjue-Agent): A Fully Reproducible, Zero-Start In-Situ Self-Evolving Agent System for Open-Ended Tasks.
 51. [Hindsight](https://github.com/vectorize-io/hindsight): State-of-the-art long-term memory for AI agents by Vectorize. Open-source, self-hostable, with integrations for LangChain, CrewAI, LlamaIndex, MCP, and more.
 52. [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh): The AI Agent Workforce Platform. Self-hostable multi-agent orchestration with remote AI workstations (AgentPods), PTY sandbox + git worktree isolation, channels-based agent collaboration, built-in Kanban, and per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode.
+53. [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent): TypeScript-native multi-agent orchestration framework with task DAGs planned at runtime, approval gates, tracing and evaluation, and checkpoint resume.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary

Add [Open Multi-Agent](https://github.com/open-multi-agent/open-multi-agent) to **智能体 Agents** using the section's numbered, one-line format.

Open Multi-Agent is a TypeScript-native multi-agent orchestration framework with task DAGs planned at runtime, approval gates, tracing and evaluation, and checkpoint resume.

## Verification

- Checked the current README and open/closed issues and pull requests for the canonical repository URL and exact project name; no existing OMA submission was found.
- Confirmed the canonical repository link returns HTTP 200.
- Ran `git diff --check`.

## Disclosure

I am a maintainer of Open Multi-Agent.
