### PR TITLE
Add Atomic Agent to the Coding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 23. [Kimi-CLI](https://github.com/MoonshotAI/kimi-cli)
 24. [opencode](https://github.com/anomalyco/opencode)
 25. [Multica](https://github.com/multica-ai/multica)
+26. [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent): Local-first coding CLI and TUI that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required. 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory system. macOS, Linux, Windows. Developer preview.
 
 
 <div align="right">


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thanks for this great list, our team would be thrilled if you added us.

Adds Atomic Agent to the 代码 Coding section as entry 26, appended after Multica so no existing entry is renumbered.

Atomic Agent is a local-first coding CLI and TUI. It runs open-weight models entirely on your machine through a llama.cpp fork, and no account or API key is required to install or run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, and has a five-layer local memory system. The TUI is built on React and ink. macOS, Linux, and Windows are supported.

Being upfront about maturity, since the list is about genuinely valuable projects rather than hype: our README carries an official notice that this is a developer preview and that APIs, commands, config, and behavior are still moving. I kept that clause in the row itself so readers see it at a glance. The repo is about 4 months old, but it is active (~2k stars, MIT licensed) and maintained by the AtomicBot-ai organization.

Install: `curl -fsSL https://atomicagent.io/install | sh`

Links:
- Repo: https://github.com/AtomicBot-ai/atomic-agent
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- X: https://x.com/atomicagent_io
- Discord: https://discord.gg/Us7qXtDGw

Checks performed:
- Grepped the whole repo for "atomic", "AtomicBot", "atomicagent" to confirm no duplicate entry
- Confirmed the project link returns 200
- Verified the Coding section numbering stays a clean 1-26 sequence
- Ran `git diff --check`

Note on naming: there is a separate, unrelated project called "Atomic Agents" (BrainBlend-AI/atomic-agents). It is not currently on this list, so there is no clash in the file, but flagging it in case you run across it later. Ours is Atomic Agent by AtomicBot.

Happy to adjust the wording, shorten the description, or move it to a different section if you prefer.
