### PR TITLE
Add DSH Studio to Harness resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 2. [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness): Everything is a Plugin.
 3. [OpenSquilla](https://github.com/opensquilla/opensquilla): a token-efficient, microkernel AI agent.
 4. [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): Your Automated Agent Builder, Right on Your Desktop / Server.
+5. [DSH Studio](https://github.com/Moresyl/dsh-studio): Cross-platform desktop interface for installing, supervising, and managing DeepSeek Harness.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
在「智能体 Agents → Harness」小节中新增 DSH Studio。

DSH Studio 是一个 MIT 开源的跨平台桌面界面，用于安装、监督和管理 DeepSeek Harness，支持 Windows、macOS 与 Linux。此次仅修改 README.md，新增一条与现有编号及描述格式一致的记录。