### PR TITLE
Add MCP Lens to Harness resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 2. [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness): Everything is a Plugin.
 3. [OpenSquilla](https://github.com/opensquilla/opensquilla): a token-efficient, microkernel AI agent.
 4. [PenguinHarness](https://github.com/Prism-Shadow/penguin-harness): Your Automated Agent Builder, Right on Your Desktop / Server.
+5. [MCP Lens](https://github.com/labmimors/dsh-mcp-lens): DeepSeek Harness plugin that keeps large MCP catalogs behind two model-facing search/call interfaces and reveals exact schemas on demand.
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary

- Add MCP Lens to `智能体 Agents → Harness`.
- Link directly to its public GitHub repository.

## Why

MCP Lens is an MIT-licensed DeepSeek Harness plugin for large MCP catalogs. It exposes two model-facing search/call interfaces and reveals exact tool schemas on demand, so it fits the existing Harness resources section.

## Maintainer disclosure

I maintain MCP Lens under the `labmimors` account.

## Checks

- `git diff --check`
- Confirmed the repository link returns HTTP 200
- Confirmed no existing `dsh-mcp-lens`, `MCP Lens`, or `labmimors` entry on live `main`, open issues, or open pull requests before submission
- Diff is limited to one README insertion
