### PR TITLE
docs: add nano-SGLang interactive tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,7 +1043,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 35. [cnblog: 第七子](https://www.cnblogs.com/theseventhson)
 36. [Implementation of all RAG techniques in a simpler way.](https://github.com/FareedKhan-dev/all-rag-techniques)
 37. [Theoretical Machine Learning: A Handbook for Everyone](https://www.tengjiaye.com/mlbook.html)
-
+38. [nano-SGLang Interactive Guide](https://github.com/lora-sys/nano-sglang-interactive-guide)：面向开发者的中文 SGLang Runtime 互动教程，提供 13 章浏览器实验、源码锚点、Trace 回放与中文原理动画，覆盖连续批处理、KV Cache、RadixAttention、Structured Outputs、Sampling、投机解码和调度机制。
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>
 </div>


### PR DESCRIPTION
## Summary

Adds **nano-SGLang Interactive Guide** to the existing `教程 Tutorial` section as item 38.

The project is an MIT-licensed, Chinese-language interactive tutorial for learning SGLang Runtime internals through 13 browser-based labs, trace/source anchors, and narrated mechanism animations.

- Repository: https://github.com/lora-sys/nano-sglang-interactive-guide
- - Live demo: https://lora-sys.github.io/nano-sglang-interactive-guide/
Its scope covers continuous batching, KV Cache, RadixAttention, structured outputs, sampling, speculative decoding, and scheduling. The project explicitly labels its concept runtime and animations as learning artifacts rather than real GPU traces or benchmark measurements.

## Checks

- Confirmed that `nano-SGLang`, `lora-sys`, and `interactive guide` are not already listed.
- - Preserved the existing numbering and Markdown format in `教程 Tutorial`.
- - Ran `git diff --check` successfully.
Happy to shorten the description or move the entry if another existing section is preferred.