### PR TITLE
docs: add nano-vLLM interactive guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,6 +1043,7 @@ To speed up Long-context LLMs' inference, approximate and dynamic sparse calcula
 35. [cnblog: 第七子](https://www.cnblogs.com/theseventhson)
 36. [Implementation of all RAG techniques in a simpler way.](https://github.com/FareedKhan-dev/all-rag-techniques)
 37. [Theoretical Machine Learning: A Handbook for Everyone](https://www.tengjiaye.com/mlbook.html)
+38. [nano-vLLM Interactive Guide](https://github.com/lora-sys/nano-vllm-interactive-guide)：面向开发者的中文 vLLM 推理机制互动教程，提供 13 个无需 GPU 的浏览器实验、源码锚点、教学 Trace 与可选真实运行路径，覆盖连续批处理、PagedAttention、KV/Prefix Cache、CUDA Graph、量化和并行推理。
 
 <div align="right">
     <b><a href="#Contents">↥ back to top</a></b>


### PR DESCRIPTION
## Summary

Adds **nano-vLLM Interactive Guide** to the existing `教程 Tutorial` list.

This MIT-licensed project is a Chinese-first, browser-based interactive guide to vLLM and nano-vLLM inference internals. It provides 13 no-GPU concept labs, source anchors, teaching traces, and an optional CUDA runtime path covering continuous batching, PagedAttention, KV/Prefix Cache, CUDA Graphs, quantization, and distributed inference.

- Repository: https://github.com/lora-sys/nano-vllm-interactive-guide
- - Live guide: https://lora-sys.github.io/nano-vllm-interactive-guide/
- - English discovery page: https://lora-sys.github.io/nano-vllm-interactive-guide/en/
The project explicitly distinguishes concept simulations from real CUDA traces and benchmark claims.

## Checks

- Confirmed that the resource is not already listed.
- - Followed the existing numbered entry format in the Tutorial section.
- - Ran `git diff --check` successfully.
- 